### PR TITLE
Added route hijacking

### DIFF
--- a/.cli_history
+++ b/.cli_history
@@ -121,3 +121,79 @@ show-router 1
 show-router 2
 show-router 3
 exity
+help
+hijack
+init-topology
+show-topology
+find-routes 4
+show-router 4
+help
+add-router 5
+show-topology
+exiyt
+init-topology
+show-topology
+add-router
+add-router 5 --neighbor 2 --relation 0
+init-topology
+show-topology
+add-router 5 --neighbor 2 --relation 0
+init-topology
+show-topology
+add-router 5 --neighbor 2 --relation 0
+show-topology
+add-router 6 --neighbor 4 --relation -1
+show-topology
+clear
+init-topology
+show-topology
+add-router 5 --neighbor 2 --relation 0
+show-topology
+init-topology
+show-topology
+add-router 5 --neighbor 2 --relation 0
+show-topology
+init-topology
+show-topology
+add-router 5 --neighbor 2 --relation 0
+show-topology
+add-router 6 --neighbor 4 --relation -1
+show-topology
+help
+hijack
+init-topology
+add-router 6 --neighbor 4 --relation -1
+add-router 5 --neighbor 2 --relation 0
+show-topology
+help
+hijack
+hijack 6 5 1
+init-topology
+show-topology
+add-router 5 --neighbor 2 --relation 0
+add-router 6 --neighbor 4 --relation -1
+show-topology
+hijack 5 6 1
+add-router 5 --neighbor 2 --relation 0
+add-router 6 --neighbor 4 --relation -1
+show-topology
+init-topology
+show-topology
+add-router 6 --neighbor 4 --relation -1
+add-router 5 --neighbor 2 --relation 0
+show-topology
+hijack 6 5 1
+show-router 2
+help
+init-topology
+add-router 5 --neighbor 2 --relation 0
+show-topology
+add-router 6 --neighbor 4 --relation -1
+show-topology
+hijack 6 5 1
+init-topology
+add-router 6 --neighbor 4 --relation -1
+add-router 5 --neighbor 2 --relation 0
+show-topology
+hijack 6 5 1
+show-topology

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -74,6 +74,14 @@ func Run(args []string) {
       Execute: func(args []string) { state.CFindRoutesTo(args) },
       Description: "Find routes to a specific destination",
     },
+    "hijack": {
+      Execute: func(args []string) { state.CHijack(args) },
+      Description: "Hijack a route",
+    },
+    "add-router": {
+      Execute: func(args []string) { state.CAddRouter(args) },
+      Description: "Add a router to the topology",
+    },
   }
 
   // Add help command later on to show available commands

--- a/cmd/cli/commands.go
+++ b/cmd/cli/commands.go
@@ -6,7 +6,7 @@ import (
   "strconv"
 
   // Internal library imports
-  // "rstk/internal/router"
+  "rstk/internal/router"
   "rstk/internal/graph"
   "rstk/internal/parser"
 
@@ -169,6 +169,87 @@ func (s *State) CFindRoutesTo(args []string) {
   // Getting the routes to the given router, using the FindRoutesTo function from
   // the topology `func (t *Topology) FindRoutesTo(target *router.Router)` 
   t.FindRoutesTo(router)
+}
+
+// Command for adding a new router to the topology
+func (s *State) CAddRouter(args []string) {
+  // First checking the arguments, there is an additional option for this
+  // according to that option variables are assigned
+  if len(args) != 5  || args[1] != "--neighbor" || args[3] != "--relation" {
+    fmt.Println("[!] Usage: add-router <AS> --neighbor ASNumber --relation <Customer(1)|Peer(0)|Provider(-1)>")
+    fmt.Println("[!] Example: add-router 1 --neighbor 2 --relation -1")
+    return
+  }
+
+  // String to integer for AS number provided
+  as := args[0]
+  asNumber, _ := strconv.Atoi(as)
+
+  // Neighbor as number
+  neighbor := args[2]
+  neighborNumber, _ := strconv.Atoi(neighbor)
+
+  // Relation between the router and the neighbor
+  relation := args[4]
+  relationNumber, _ := strconv.Atoi(relation)
+
+  // Getting the topology from the state
+  t := s.Topology
+
+  // Checking the arguments
+  // TODO for now same AS added every time this command is called, this should be
+  // called with either parameters provided as arguments, configurations or other
+  // methods (need to create router instance and neighbor instances here)
+  r := router.NewRouter(asNumber)
+  
+  // Adding neighbor the routers neighbor list with its provided relation
+  
+  r.Neighbors = append(r.Neighbors, router.Neighbor{
+    Router: t.GetRouter(fmt.Sprintf("r%d", neighborNumber)), 
+    Relation: router.Relation(relationNumber),
+  })
+
+  fmt.Printf("[+] Printing router object as string:\n%s\n", r.ToString())
+
+  // Adding the router to the topology
+  fmt.Println("[+] Adding router to the topology...")
+  t.AddRouter(r)
+}
+
+// Command for adding route hijacking to the topology
+func (s *State) CHijack(args []string) {
+  // Validating the arguments
+  if len(args) != 3 {
+    fmt.Println("[!] Usage: hijack-route <victim> <attacker> <Number of Hops>")
+    return
+  }
+
+  // Getting the topology from the state
+  t := s.Topology
+
+  // Casting the string to integer then hashing it then, accessing it via
+  // GetRouter method since the method requires hashed version of the idenfitifer
+  // of the router
+  as1 := args[0] // Victim AS
+  as2 := args[1] // Attacker AS
+  hops := args[2]
+
+  // Casting it to integer
+  asNumber1, _ := strconv.Atoi(as1)
+  asNumber2, _ := strconv.Atoi(as2)
+  numHops, _ := strconv.Atoi(hops)
+
+  // Hashing the as number (int) to hashed string version of it
+  asHash1 := fmt.Sprintf("r%d", asNumber1)
+  asHash2 := fmt.Sprintf("r%d", asNumber2)
+
+  // Getting the router from the topology
+  router1 := t.GetRouter(asHash1)
+  router2 := t.GetRouter(asHash2)
+
+  // Hijacking the route
+  fmt.Println("[+] Hijacking route...")
+  t.Hijack(router1, router2, numHops)
 }
 
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -20,8 +20,10 @@
 - [ ] Fully testing routing logic on a simple test topology
 - [ ] Implementing ASPA 
 - [ ] Implementing Prefix Hijacking
-- [ ] There is some inconsistencies between so called 'Helper' functions and methods, 'Helper' functions shouldn't
-      be methods or some other solution might be needed
+- [ ] There is some inconsistencies between so called 'Helper' functions and methods, 'Helper' functions shouldn't be methods or some other solution might be needed
+- [ ] When adding a new router to the topology if the router already exists in the topology then following operations are not currently handled (for temporarily assuming everytime a new unique router is added to the topology, since our test topology is small)
+- [ ] Referencing routers, from topology, when adding a new router, especially when working with neighbors is a bit problematic, sometimes new instances of a router could mistakenly referenced instead of the actual router instances from the topology, also ASES synchronizaiton with the topology is another problem, when adding a new router to topology ASES needs the same treatment as well, with all the routers etc.
+    - [ ] Might resolve this by referncing routers with the AS number from the topology directly when building the ASES
 
 # Plan
 Initial design should be as close as possible to fully abstracted BGP routing simulator only, routing should be done on ASes only > Try to turn this into hybrid approach as outlined on the design.md && Try to replicate ASPA deployment startegies > Alternative approach > In-network part

--- a/internal/graph/adversary.go
+++ b/internal/graph/adversary.go
@@ -1,0 +1,113 @@
+package graph
+
+// Adversary contains, all the malicious actions, prefix hijacks, route leak configurations
+// and other custom actions, mainly AS path manipulations
+
+import (
+  // Core library imports
+  "fmt"
+  "time"
+  "math/rand"
+
+  // Internal library imports
+  "rstk/internal/router"
+
+  // Github library imports
+	"github.com/edwingeng/deque"
+  log "github.com/sirupsen/logrus"
+
+)
+
+
+// Method for hijacking given n hops, such as n = 0 means, path is only the attacker itself,
+// n = 1 means path is attacker and victim AS, and more then n means there are random or 
+// carefuly crafted ASes in the middle
+func (t *Topology) Hijack(victim *router.Router, attacker *router.Router, n int) {
+  log.Infof("Starting route hijacking from attacker AS%d to vicmtim AS%d", victim.ASNumber, 
+    attacker.ASNumber)
+  if n < 0 {
+    fmt.Println("number of hops must be non-negative")
+    return
+  }
+
+  var path []*router.Router
+
+  if n == 0 {
+    // Attacker claims to be the originpath
+    log.Debugf("Attacker claims to be the origin")
+    path = []*router.Router{attacker}
+  } else if n == 1 {
+    // Attacker claims a direct path to victim
+    log.Debugf("Attacker claims a direct path to victim")
+    path = []*router.Router{victim, attacker}
+  } else {
+    // Attacker includes random ASes in the path
+    // Exclude victim and attacker from the list of ASes
+    log.Debugf("Attacker includes random ASes in the path")
+    asysSet := make(map[int]*router.Router)
+    for asn, asys := range t.ASES {
+        if asn != victim.ASNumber && asn != attacker.ASNumber {
+            asysSet[asn] = asys
+        }
+    }
+
+    // Convert map to slice for sampling
+    asysList := make([]*router.Router, 0, len(asysSet))
+    for _, asys := range asysSet {
+        asysList = append(asysList, asys)
+    }
+
+    // Randomly select n-1 ASes
+    if n-1 > len(asysList) {
+        fmt.Println("Not enough ASes to build the path")
+        return
+    }
+    middle := randomSample(asysList, n-1)
+
+    // Build the path: [victim] + middle ASes + [attacker]
+    path = []*router.Router{victim}
+    path = append(path, middle...)
+    path = append(path, attacker)
+  }
+
+  badRoute := &router.Route{
+    Dest:           victim,
+    Path:           path,
+    OriginInvalid:  n == 0,
+    PathEndInvalid: n <= 1,
+    Authenticated:  false,
+  }
+
+  log.Debugf("Constructed random bad route %v", badRoute.PathASNumbers())
+
+  routes := deque.NewDeque()
+  for _, neighbor := range attacker.Neighbors {
+    forwardedRoute := attacker.ForwardRoute(badRoute, neighbor.Router)
+    routes.PushBack(forwardedRoute)
+    log.Debugf("Adding neighbor AS%d to the queue", neighbor.Router.ASNumber)
+  }
+  
+  for routes.Len() > 0 {
+    route := routes.PopFront().(*router.Route)
+    final := route.Path[len(route.Path)-1]
+    log.Debugf("Processing route to AS%d via AS%d", route.Dest.ASNumber, final.ASNumber)
+
+    // Forward the route to neighbors according to policy
+    for _, neighbor := range final.LearnRoute(route) {
+     routes.PushBack(final.ForwardRoute(route, neighbor))
+     log.Debugf("Forwarded route from AS%d to neighbor AS%d", final.ASNumber, neighbor.ASNumber)
+    }
+  }
+  log.Infof("Completed hijacking")
+}
+
+
+func randomSample(asysList []*router.Router, k int) []*router.Router {
+  rand.Seed(time.Now().UnixNano())
+  shuffled := make([]*router.Router, len(asysList))
+  copy(shuffled, asysList)
+  rand.Shuffle(len(shuffled), func(i, j int) {
+    shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+  })
+  return shuffled[:k]
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -32,7 +32,8 @@ import (
 // heavily focused on BGP routing, so node relations are included in the code as well, most of the
 // data structures are related to BGP context, this will in the future, with the graph, also will
 // be abstracted away with more modular structure, with either a scripting with 'lua' or 'python'
-// or some templating or some configurations
+// or some templating or some configurations user be able to create their own topologies, with their
+// own routing, policy, route logics, etc.
 
 // Below are all the data strcutres used within the topology
 
@@ -145,6 +146,88 @@ func (t* Topology) Init(asRelsList []parser.AsRel) (graph.Graph[string, *router.
 	return g, ases
 }
 
+// Adds a router to the topology, that is alread intialized with the Init() function
+// used for including different type of routers to support different type of scenarios
+// such as introducing a rouge router, that conducts prefix hijacking, or route leaking
+// etc.
+func (t *Topology) AddRouter(r *router.Router) {
+    // Check if topology is initialized
+    if t.G == nil {
+        fmt.Println("Topology is not initialized yet")
+        return
+    }
+
+    // Check if the router with the same AS number already exists
+    if _ , exists := t.ASES[r.ASNumber]; exists {
+        fmt.Printf("Router with AS%d already exists, adding it as a hijacker\n", r.ASNumber)
+        fmt.Printf("Duplicate routers will exist in the graph\n")
+        fmt.Printf("Overwriting existing one, all routing information will be lost\n")
+        
+        // **Important:** Instead of overwriting, consider handling multiple routers per ASNumber
+        // For simplicity, we'll proceed with overwriting but note the caveat
+        t.ASES[r.ASNumber] = r
+    } else {
+        // Add the new router to the ASES map
+        t.ASES[r.ASNumber] = r
+    }
+
+    // Validate that all specified neighbors exist in the topology
+    for _, neighbor := range r.Neighbors {
+        if _, exists := t.ASES[neighbor.Router.ASNumber]; !exists {
+            fmt.Printf("Neighbor with AS%d does not exist in the topology\n", neighbor.Router.ASNumber)
+            return
+        }
+    }
+
+    // Add the new router to the graph
+    _ = t.G.AddVertex(r)
+
+    // Establish bidirectional edges in the graph
+    for _, neighbor := range r.Neighbors {
+        neighborHash := RouterHash(neighbor.Router)
+        _ = t.G.AddEdge(RouterHash(r), neighborHash, graph.EdgeWeight(int(neighbor.Relation)))
+        _ = t.G.AddEdge(neighborHash, RouterHash(r), graph.EdgeWeight(int(inverseRelation(neighbor.Relation))))
+    }
+
+    // Update Neighbor Routers' Neighbor Lists
+    for _, neighbor := range r.Neighbors {
+        // existingNeighbor := t.ASES[neighbor.Router.ASNumber] // Retrieve from ASES map
+        existingNeighbor := t.GetRouter(RouterHash(neighbor.Router))
+        inverseRel := inverseRelation(neighbor.Relation)
+
+        // Create a new Neighbor instance for the existing neighbor to include the new router
+        newNeighbor := router.Neighbor{
+            Relation: inverseRel,
+            Router:   r,
+        }
+
+        // Check if the new router is already a neighbor to avoid duplicates
+        alreadyNeighbor := false
+        for _, n := range existingNeighbor.Neighbors {
+            if n.Router.ASNumber == r.ASNumber {
+                alreadyNeighbor = true
+                log.Infof("AS%d is already a neighbor to AS%d with relation %d", n.Router.ASNumber, 
+                  r.ASNumber, n.Relation)
+                break
+            }
+        }
+
+        // Append the new neighbor if not already present
+        if !alreadyNeighbor {
+            existingNeighbor.Neighbors = append(existingNeighbor.Neighbors, newNeighbor)
+            log.Infof("Added AS%d as a neighbor to AS%d with relation %d", r.ASNumber, 
+                existingNeighbor.ASNumber, inverseRel)
+        }
+    }
+
+    // Update the adjacency and predecessor maps
+    t.AdjMap, _ = t.G.AdjacencyMap()
+    t.PredMap, _ = t.G.PredecessorMap()
+
+    log.Infof("Successfully added Router AS%d to the topology", r.ASNumber)
+}
+
+ 
 // Main routing related function for finding routes to a specific destination, it is 
 // the one of the core functions within the routing logic of the simulator
 func (t *Topology) FindRoutesTo(target *router.Router) {
@@ -237,3 +320,31 @@ func inverseRelation(rel router.Relation) router.Relation {
 func RouterHash(r *router.Router) string {
   return fmt.Sprintf("r%d", r.ASNumber)
 }
+
+// Method for determining reachability of a given AS, from every other AS in the graph,
+// ASes are taken from the AS map initialized in the Init() function, and for each AS
+// obtained from that map, GetRouter function is called and from there on the reachability
+// of the AS is calculated
+//
+// In the original Python code, following approach is preferred, utilizing more of the graph
+// packages methods. 
+func (t *Topology) Reachability() {
+
+}
+
+// Method for determining reachability of every AS to every other AS in the graph. It is
+// expensive operation, most probably performs worse on larget topologies
+// TODO could research on faster ways, parallelizing, caching, memoization etc.
+func (t *Topology) ReachabilityAll() {
+
+}
+
+// Helpre function for Reachability and ReachabilityAll functions, it builds a reachability graph
+// of the whole topology, with left and right indicators for each AS. It constructs in the end
+// a directed graph
+func (t* Topology) BuildReachabilityGraph() {
+
+}
+
+
+

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -55,7 +55,6 @@ func (n Neighbor) ToString() string {
 	return fmt.Sprintf("<AS%d (%d)>", n.Router.ASNumber, n.Relation)
 }
 
-
 // Method for returning humand readable string representation of a router
 func (r Router) ToString() string {
 	var sb strings.Builder
@@ -155,7 +154,8 @@ func (r *Router) LearnRoute(route *Route) []*Router {
   for _, neighbor := range r.Neighbors {
     if forwardToRelations[neighbor.Relation] {
       neighbors = append(neighbors, neighbor.Router)
-      log.Debugf("AS%d will forward route to neighbor AS%d (relation: %v)", r.ASNumber, neighbor.Router.ASNumber, neighbor.Relation)      
+      log.Debugf("AS%d will forward route to neighbor AS%d (relation: %v)", r.ASNumber, 
+        neighbor.Router.ASNumber, neighbor.Relation)      
     }
   }
   return neighbors
@@ -185,6 +185,18 @@ func (r *Router) getNeighborsByRelation(relation Relation) []Neighbor {
         }
     }
     return neighbors
+}
+
+// Method for creating a new router instance, only AS number is required for creating
+// rest is set to default values, such as empty routing table, empty neighbors etc. 
+// user can set these values later on
+func NewRouter(asNumber int) *Router {
+  return &Router{
+    Neighbors:  []Neighbor{},
+    RouteTable: make(map[int]*Route),
+    ASNumber:   asNumber,
+    Policy:     Policy{PolicyType: "DefaultPolicy"},
+  }
 }
 
 // Function for forcing route, in some cases, route needs to be forced without pre-checks
@@ -219,5 +231,4 @@ func (r *Router) ForwardRoute(route *Route, nextHop *Router) *Route {
         Authenticated:   true,
     }
 }
-
 


### PR DESCRIPTION
This pull request introduces several new commands and functionalities to the CLI, enhances the internal graph and router packages, and updates the documentation to reflect these changes. The most important changes include adding commands for route hijacking and router addition, implementing the `AddRouter` method in the topology, and enhancing the adversary capabilities in the graph package.

### New CLI Commands:
* [`cmd/cli/cli.go`](diffhunk://#diff-cd2c47403e307c3c964d58a90430910400f18ba2acb432c474caefcaccfcf5f1R77-R84): Added new commands `hijack` and `add-router` with corresponding descriptions and execution functions.
* [`cmd/cli/commands.go`](diffhunk://#diff-e8b947cc42b1b2406ff6bd2ce2ba650240f7242e3aa2ef431b49cedff183a46dR174-R254): Implemented `CAddRouter` and `CHijack` methods to handle adding routers and hijacking routes, respectively.

### Graph and Router Enhancements:
* [`internal/graph/graph.go`](diffhunk://#diff-a918a3cf9f028a70ef671823b8aab0bd9c7862aa755f4486a1c2aac013cc497bR149-R230): Implemented the `AddRouter` method to add routers to the topology, including validation and updating neighbor lists.
* [`internal/graph/adversary.go`](diffhunk://#diff-42af4716768dd0befbb59bc1a079b6abbc25ecb2ec56588405928adef1a64fd8R1-R113): Added a new `Hijack` method to simulate route hijacking with specified hops.
* [`internal/router/router.go`](diffhunk://#diff-42334ff60169cad0d1fa0b868b836e5156659fcf78cb8b20800bf0b829a4e6deR190-R201): Added a `NewRouter` method to create router instances with default values.

### Documentation Updates:
* [`docs/todo.md`](diffhunk://#diff-d84697334acf64fe5d67dfd34f6370dca462f602aa3a720711eae12bf8dd153dL23-R26): Updated the TODO list to reflect new tasks related to router addition and referencing issues.

These changes significantly enhance the functionality and flexibility of the CLI and the underlying topology management.